### PR TITLE
Job generator for kernel and lttng-modules

### DIFF
--- a/jobs/ops_job-generator_kernel.yaml
+++ b/jobs/ops_job-generator_kernel.yaml
@@ -1,0 +1,50 @@
+- job:
+    name: ops_job-generator_kernel
+    description: |
+      The kernel job generator auto generate from jenkins job builder all the
+      kernel and lttng-modules jobs.
+
+      <p>Job is managed by Jenkins Job Builder.</p>
+
+    project-type: freestyle
+    logrotate:
+      daysToKeep: -1
+      numToKeep: 2
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    wrappers:
+      - workspace-cleanup
+      - timestamps
+      - ansicolor:
+          colormap: xterm
+      - credentials-binding:
+        - username-password-separated:
+            credential-id: 72e4d7dd-6c82-413d-ab79-d89d7e6bc959
+            username: JJB_JENKINS_USER
+            password: JJB_JENKINS_TOKEN
+
+    triggers:
+      - timed: '@daily'
+
+    scm:
+      - git:
+          url: https://github.com/lttng/lttng-ci.git
+          branches:
+            - origin/master
+
+
+    builders:
+      - shell: |
+          git clone --reference $HOME/gitcache/linux-stable.git/ git://artifacts.internal.efficios.com/git/linux-stable.git kernel
+      - shell:
+          !include-raw-escape: scripts/kernel/job-generator-kernel.sh
+      - system-groovy:
+          file: "scripts/kernel/job-trigger-kernel.groovy"
+
+    publishers:
+      - workspace-cleanup
+      - email:
+          recipients: joraj@efficios.com
+
+

--- a/scripts/kernel/job-generator-kernel.sh
+++ b/scripts/kernel/job-generator-kernel.sh
@@ -1,0 +1,50 @@
+#!/bin/sh -ex
+#
+# Copyright (C) 2016 - Jonathan Rajotte-Julien <jonathan.rajotte-julien@efficios.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+PYTHON_2_ENV=$WORKSPACE"/.python2_venv"
+PYTHON_3_ENV=$WORKSPACE"/.python3_venv"
+
+virtualenv -p python2 $PYTHON_2_ENV
+virtualenv -p python3 $PYTHON_3_ENV
+
+# Prepare python 3 env
+. $PYTHON_3_ENV/bin/activate
+pip install gitpython
+pip install pyyaml
+
+# Run the kernel seed generator
+python $WORKSPACE/automation/kernel-seed.py --kernel-path $WORKSPACE/kernel --kernel-cutoff 2.6.36 > $WORKSPACE/jobs/inc/kernel-versions.yaml.inc
+
+deactivate
+
+# Prepare JJB python 2 environment
+. $PYTHON_2_ENV/bin/activate
+pip install git+git://github.com/mjeanson/jenkins-job-builder
+
+cp $WORKSPACE/etc/jenkins_jobs.ini-sample $WORKSPACE/etc/jenkins_jobs.ini
+
+# Prepare configuration file
+set +x
+sed -i -e "s/user=jenkins/user=$JJB_JENKINS_USER/g" $WORKSPACE/etc/jenkins_jobs.ini
+sed -i -e "s/password=1234567890abcdef1234567890abcdef/password=$JJB_JENKINS_TOKEN/g" $WORKSPACE/etc/jenkins_jobs.ini
+set -x
+
+jenkins-jobs --conf $WORKSPACE/etc/jenkins_jobs.ini delete --path $WORKSPACE/jobs/lttng-modules.yaml:$WORKSPACE/jobs/kernel.yaml \*rc\*_build
+jenkins-jobs --conf $WORKSPACE/etc/jenkins_jobs.ini update $WORKSPACE/jobs/lttng-modules.yaml:$WORKSPACE/jobs/kernel.yaml
+
+deactivate
+# EOF

--- a/scripts/kernel/job-trigger-kernel.groovy
+++ b/scripts/kernel/job-trigger-kernel.groovy
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2016 - Jonathan Rajotte-Julien <jonathan.rajotte-julien@efficios.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import hudson.model.*
+import hudson.AbortException
+import hudson.console.HyperlinkNote
+import java.util.concurrent.CancellationException
+
+
+def jobs = hudson.model.Hudson.instance.items
+def jobStartWith = "kernel_"
+def toBuild = []
+def counter = 0
+
+def anotherBuild
+jobs.each { job ->
+	def jobName = job.getName()
+	if (jobName.startsWith(jobStartWith)) {
+		counter = counter + 1
+		def lastBuild = job.getLastBuild()
+		if (lastBuild == null || lastBuild.result != Result.SUCCESS) {
+			toBuild.push(job)
+		} else {
+			println("\t"+ jobName + " Already built")
+		}
+	}
+}
+
+def ongoingBuild = []
+def maxConcurrentBuild = 4
+
+while (toBuild.size() != 0) {
+	if(ongoingBuild.size() <= maxConcurrentBuild) {
+		def job = toBuild.pop()
+		ongoingBuild.push(job.scheduleBuild2(0))
+		println "\t triggering " + HyperlinkNote.encodeTo('/' + job.url, job.fullDisplayName)
+	} else {
+		sleep(5000)
+		ongoingBuild.removeAll{ it.isCancelled() || it.isDone() }
+	}
+}


### PR DESCRIPTION
@mjeanson  could you review this?

See this jobs log https://ci.lttng.org/job/job_generator_kernel/.

Will need to be regenerated once it's merged since for now it use my repo for lttng-ci.

Thanks