### PR TITLE
Run generator_kernel on master and keep the version state

### DIFF
--- a/etc/jenkins_jobs.ini-sample
+++ b/etc/jenkins_jobs.ini-sample
@@ -1,5 +1,5 @@
 [job_builder]
-ignore_cache=True
+ignore_cache=False
 keep_descriptions=True
 
 [jenkins]

--- a/jobs/ops_job-generator_kernel.yaml
+++ b/jobs/ops_job-generator_kernel.yaml
@@ -1,5 +1,6 @@
 - job:
     name: ops_job-generator_kernel
+    node: master
     description: |
       The kernel job generator auto generate from jenkins job builder all the
       kernel and lttng-modules jobs.
@@ -14,7 +15,6 @@
       artifactNumToKeep: -1
 
     wrappers:
-      - workspace-cleanup
       - timestamps
       - ansicolor:
           colormap: xterm
@@ -32,18 +32,15 @@
           url: https://github.com/lttng/lttng-ci.git
           branches:
             - origin/master
-
+          wipe-workspace: false
 
     builders:
-      - shell: |
-          git clone --reference $HOME/gitcache/linux-stable.git/ git://artifacts.internal.efficios.com/git/linux-stable.git kernel
       - shell:
           !include-raw-escape: scripts/kernel/job-generator-kernel.sh
       - system-groovy:
           file: "scripts/kernel/job-trigger-kernel.groovy"
 
     publishers:
-      - workspace-cleanup
       - email:
           recipients: joraj@efficios.com
 

--- a/scripts/kernel/job-generator-kernel.sh
+++ b/scripts/kernel/job-generator-kernel.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 #
 # Copyright (C) 2016 - Jonathan Rajotte-Julien <jonathan.rajotte-julien@efficios.com>
 #
@@ -18,33 +18,60 @@
 PYTHON_2_ENV=$WORKSPACE"/.python2_venv"
 PYTHON_3_ENV=$WORKSPACE"/.python3_venv"
 
-virtualenv -p python2 $PYTHON_2_ENV
-virtualenv -p python3 $PYTHON_3_ENV
+# Prepare JJB python 2 environment
+set -x
+if [ ! -d "$PYTHON_2_ENV" ]; then
+	virtualenv -p python2 $PYTHON_2_ENV
+fi
+set +x
 
-# Prepare python 3 env
-. $PYTHON_3_ENV/bin/activate
-pip install gitpython
-pip install pyyaml
-
-# Run the kernel seed generator
-python $WORKSPACE/automation/kernel-seed.py --kernel-path $WORKSPACE/kernel --kernel-cutoff 2.6.36 > $WORKSPACE/jobs/inc/kernel-versions.yaml.inc
-
+. $PYTHON_2_ENV/bin/activate
+pip install --force-reinstall git+git://github.com/mjeanson/jenkins-job-builder@ci
 deactivate
 
-# Prepare JJB python 2 environment
-. $PYTHON_2_ENV/bin/activate
-pip install git+git://github.com/mjeanson/jenkins-job-builder@ci
+# Prepare python 3 env
+if [ ! -d "$PYTHON_3_ENV" ]; then
+	virtualenv -p python3 $PYTHON_3_ENV
+fi
 
+. $PYTHON_3_ENV/bin/activate
+pip install --upgrade gitpython pyyaml
+deactivate
+
+# Prepare the configuration file for jjb
 cp $WORKSPACE/etc/jenkins_jobs.ini-sample $WORKSPACE/etc/jenkins_jobs.ini
 
-# Prepare configuration file
+# Set +x: hide information from the jenkins console log since we use injected
+# secrets
 set +x
 sed -i -e "s/user=jenkins/user=$JJB_JENKINS_USER/g" $WORKSPACE/etc/jenkins_jobs.ini
 sed -i -e "s/password=1234567890abcdef1234567890abcdef/password=$JJB_JENKINS_TOKEN/g" $WORKSPACE/etc/jenkins_jobs.ini
 set -x
 
-jenkins-jobs --conf $WORKSPACE/etc/jenkins_jobs.ini delete --path $WORKSPACE/jobs/lttng-modules.yaml:$WORKSPACE/jobs/kernel.yaml \*rc\*_build
-jenkins-jobs --conf $WORKSPACE/etc/jenkins_jobs.ini update $WORKSPACE/jobs/lttng-modules.yaml:$WORKSPACE/jobs/kernel.yaml
+#Prepare the kernel
+if [ ! -d "$WORKSPACE/kernel" ]; then
+	git clone git://artifacts.internal.efficios.com/git/linux-stable.git $WORKSPACE/kernel
+else
+	pushd $WORKSPACE/kernel
+	git fetch --tags origin
+	popd
+fi
 
+# Clean the previous rc
+# Note: this step is stateful since it use the last generated version.
+. $PYTHON_2_ENV/bin/activate
+jenkins-jobs --conf $WORKSPACE/etc/jenkins_jobs.ini delete --path $WORKSPACE/jobs/lttng-modules.yaml:$WORKSPACE/jobs/kernel.yaml \*rc\*_build
 deactivate
+
+# Run the kernel seed generator
+. $PYTHON_3_ENV/bin/activate
+python $WORKSPACE/automation/kernel-seed.py --kernel-path $WORKSPACE/kernel --kernel-cutoff 2.6.36 > $WORKSPACE/jobs/inc/kernel-versions.yaml.inc
+deactivate
+
+. $PYTHON_2_ENV/bin/activate
+jenkins-jobs --conf $WORKSPACE/etc/jenkins_jobs.ini update $WORKSPACE/jobs/lttng-modules.yaml:$WORKSPACE/jobs/kernel.yaml
+deactivate
+
+# Flush the configuration file so no one can access it
+rm -f $WORKSPACE/etc/jenkins_jobs.ini
 # EOF


### PR DESCRIPTION
Since the rc are deleted based on the previous version file it's imperative to
keep it from time to time to ensure deletion of unwanted rc jobs.

@mjeanson mind looking at this ?