### PR TITLE
Test only supported LTTng versions

### DIFF
--- a/jobs/lttng-baremetal-tests.yaml
+++ b/jobs/lttng-baremetal-tests.yaml
@@ -484,8 +484,8 @@
       - v4.8.1
     lttngversion:
       - master
-      - stable-2.8
       - stable-2.9
+      - stable-2.10
     jobs:
       - 'vm_tests_k{kversion}_l{lttngversion}'
       - 'baremetal_benchmarks_k{kversion}_l{lttngversion}'


### PR DESCRIPTION
Replace stable-2.8 tests by stable-2.10.