### PR TITLE
Fix lava benchmark git clone path

### DIFF
--- a/lava/baremetal-tests/failing-close.yml
+++ b/lava/baremetal-tests/failing-close.yml
@@ -15,13 +15,13 @@ install:
                   branch: master
         steps:
                 - export TMPDIR="/tmp"
-                - export BENCHMARK_DIR=$(mktemp --directory)
                 - ulimit -c unlimited
                 - mkdir -p coredump
                 - echo "$(pwd)/coredump/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 run:
         steps:
                 - source /root/lttngvenv/activate
+                - export BENCHMARK_DIR=$(mktemp --directory)/bm
                 - git clone https://github.com/frdeso/syscall-bench-it.git $BENCHMARK_DIR
                 - cd $BENCHMARK_DIR
                 - lava-test-case build-benchmarks --shell "make"

--- a/lava/baremetal-tests/failing-ioctl.yml
+++ b/lava/baremetal-tests/failing-ioctl.yml
@@ -15,13 +15,13 @@ install:
                   branch: master
         steps:
                 - export TMPDIR="/tmp"
-                - export BENCHMARK_DIR=$(mktemp --directory)
                 - ulimit -c unlimited
                 - mkdir -p coredump
                 - echo "$(pwd)/coredump/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 run:
         steps:
                 - source /root/lttngvenv/activate
+                - export BENCHMARK_DIR=$(mktemp --directory)/bm
                 - git clone https://github.com/frdeso/syscall-bench-it.git $BENCHMARK_DIR
                 - cd $BENCHMARK_DIR
                 - lava-test-case build-benchmarks --shell "make"

--- a/lava/baremetal-tests/failing-open-efault.yml
+++ b/lava/baremetal-tests/failing-open-efault.yml
@@ -15,13 +15,13 @@ install:
                   branch: master
         steps:
                 - export TMPDIR="/tmp"
-                - export BENCHMARK_DIR=$(mktemp --directory)
                 - ulimit -c unlimited
                 - mkdir -p coredump
                 - echo "$(pwd)/coredump/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 run:
         steps:
                 - source /root/lttngvenv/activate
+                - export BENCHMARK_DIR=$(mktemp --directory)/bm
                 - git clone https://github.com/frdeso/syscall-bench-it.git $BENCHMARK_DIR
                 - cd $BENCHMARK_DIR
                 - lava-test-case build-benchmarks --shell "make"

--- a/lava/baremetal-tests/failing-open-enoent.yml
+++ b/lava/baremetal-tests/failing-open-enoent.yml
@@ -15,13 +15,13 @@ install:
                   branch: master
         steps:
                 - export TMPDIR="/tmp"
-                - export BENCHMARK_DIR=$(mktemp --directory)
                 - ulimit -c unlimited
                 - mkdir -p coredump
                 - echo "$(pwd)/coredump/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 run:
         steps:
                 - source /root/lttngvenv/activate
+                - export BENCHMARK_DIR=$(mktemp --directory)/bm
                 - git clone https://github.com/frdeso/syscall-bench-it.git $BENCHMARK_DIR
                 - cd $BENCHMARK_DIR
                 - lava-test-case build-benchmarks --shell "make"
@@ -35,4 +35,3 @@ run:
                 - tar czf coredump.tar.gz coredump
                 - lava-test-case-attach run-benchmarks coredump.tar.gz
                 - lava-test-case-attach run-benchmarks "./processed_results_open_enoent.csv"
-

--- a/lava/baremetal-tests/lttng-test-filter.yml
+++ b/lava/baremetal-tests/lttng-test-filter.yml
@@ -10,9 +10,6 @@ install:
                 - python3-pandas
                 - python3-numpy
         git-repos:
-                - url: https://github.com/frdeso/syscall-bench-it.git
-                  destination: /tmp/benchmarks
-                  branch: master
                 - url: https://github.com/lttng/lttng-ci
                   destination: ci
                   branch: master
@@ -24,14 +21,16 @@ install:
 run:
         steps:
                 - source /root/lttngvenv/activate
-                - cd /tmp/benchmarks
+                - export BENCHMARK_DIR=$(mktemp --directory)/bm
+                - git clone https://github.com/frdeso/syscall-bench-it.git $BENCHMARK_DIR
+                - cd $BENCHMARK_DIR
                 - modprobe lttng-test
                 - lava-test-case build-benchmarks --shell "make"
                 - lava-test-case run-benchmarks --shell "./run.sh lttng-test-filter lttng_test_filter_event"
                 - lava-test-case-attach run-benchmarks "./results.csv"
                 - cd -
                 - cd ci
-                - python3 ./scripts/lttng-baremetal-tests/parse-results.py /tmp/benchmarks/results.csv
+                - python3 ./scripts/lttng-baremetal-tests/parse-results.py $BENCHMARK_DIR/results.csv
                 - mv ./processed_results.csv ../processed_results_lttng_test_filter.csv
                 - cd -
                 - tar czf coredump.tar.gz coredump

--- a/lava/baremetal-tests/raw-syscall-getpid.yml
+++ b/lava/baremetal-tests/raw-syscall-getpid.yml
@@ -15,13 +15,13 @@ install:
                   branch: master
         steps:
                 - export TMPDIR="/tmp"
-                - export BENCHMARK_DIR=$(mktemp --directory)
                 - ulimit -c unlimited
                 - mkdir -p coredump
                 - echo "$(pwd)/coredump/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 run:
         steps:
                 - source /root/lttngvenv/activate
+                - export BENCHMARK_DIR=$(mktemp --directory)/bm
                 - git clone https://github.com/frdeso/syscall-bench-it.git $BENCHMARK_DIR
                 - cd $BENCHMARK_DIR
                 - lava-test-case build-benchmarks --shell "make"

--- a/lava/baremetal-tests/success-dup-close.yml
+++ b/lava/baremetal-tests/success-dup-close.yml
@@ -15,13 +15,13 @@ install:
                   branch: master
         steps:
                 - export TMPDIR="/tmp"
-                - export BENCHMARK_DIR=$(mktemp --directory)
                 - ulimit -c unlimited
                 - mkdir -p coredump
                 - echo "$(pwd)/coredump/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 run:
         steps:
                 - source /root/lttngvenv/activate
+                - export BENCHMARK_DIR=$(mktemp --directory)/bm
                 - git clone https://github.com/frdeso/syscall-bench-it.git $BENCHMARK_DIR
                 - cd $BENCHMARK_DIR
                 - lava-test-case build-benchmarks --shell "make"


### PR DESCRIPTION
The clone target directory must not exist.
Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>