### PR TITLE
Fix: YAML does not support object merging or array merging for anchor

### DIFF
--- a/jobs/babeltrace.yaml
+++ b/jobs/babeltrace.yaml
@@ -148,6 +148,19 @@
 - babeltrace_build_publishers_prod: &babeltrace_build_publishers_prod
     name: 'babeltrace_build_publishers_prod'
     publishers:
+      - tap:
+          results: 'tap/**/*.log'
+          failed-tests-mark-build-as-failure: true
+          todo-is-failure: false
+      - warnings:
+          console-log-parsers:
+            - 'GNU Make + GNU C Compiler (gcc)'
+          total-thresholds:
+            unstable:
+              total-all: 0
+              total-high: 0
+              total-normal: 0
+              total-low: 0
       - archive:
           artifacts: 'build/**'
           allow-empty: false
@@ -165,7 +178,6 @@
 
     <<: *babeltrace_build_axes_defaults
     <<: *babeltrace_build_builders_defaults
-    <<: *babeltrace_build_publishers_defaults
     <<: *babeltrace_build_publishers_prod
 
 - job-template:
@@ -174,7 +186,6 @@
 
     <<: *babeltrace_build_axes_defaults
     <<: *babeltrace_build_builders_win
-    <<: *babeltrace_build_publishers_defaults
     <<: *babeltrace_build_publishers_prod
 
 - job-template:

--- a/jobs/lttng-tools.yaml
+++ b/jobs/lttng-tools.yaml
@@ -297,6 +297,22 @@
 - lttng-tools_build_publishers_prod: &lttng-tools_build_publishers_prod
     name: 'lttng-tools_build_publishers_prod'
     publishers:
+      - tap:
+          results: 'tap/**/*.tap'
+          failed-tests-mark-build-as-failure: true
+          todo-is-failure: false
+      - warnings:
+          console-log-parsers:
+            - 'GNU Make + GNU C Compiler (gcc)'
+          total-thresholds:
+            unstable:
+              total-all: 0
+              total-high: 0
+              total-normal: 0
+              total-low: 0
+      - workspace-cleanup:
+          clean-if:
+            - failure: false
       - archive:
           artifacts: 'build/**'
           allow-empty: false
@@ -314,7 +330,6 @@
 
     <<: *lttng-tools_build_axes_defaults
     <<: *lttng-tools_build_builders_defaults
-    <<: *lttng-tools_build_publishers_defaults
     <<: *lttng-tools_build_publishers_prod
 
     triggers:
@@ -330,7 +345,6 @@
 
     <<: *lttng-tools_build_axes_defaults
     <<: *lttng-tools_build_builders_win
-    <<: *lttng-tools_build_publishers_defaults
     <<: *lttng-tools_build_publishers_prod
 
 - job-template:


### PR DESCRIPTION
Publisher anchors do not behave as expected. They overwrite each other
instead of merging their array values (irc notification, tap parsing, etc.)

Yaml does not support array merging via anchor [1]. Duplicate the
"default" value into the more defined publisher anchor.

[1] https://stackoverflow.com/questions/24090177/how-to-merge-yaml-arrays/30770740#30770740

Signed-off-by: Jonathan Rajotte <jonathan.rajotte-julien@efficios.com>