### PR TITLE
Use setResult instead of getExecutor().interrupt to set FAILURE

### DIFF
--- a/scripts/latency-tracker/master-rt.groovy
+++ b/scripts/latency-tracker/master-rt.groovy
@@ -354,7 +354,7 @@ for (b in allBuilds) {
 
 // Mark this build failed if any child build has failed
 if (isFailed) {
-  build.getExecutor().interrupt(Result.FAILURE)
+  build.setResult(hudson.model.Result.FAILURE)
 }
 
 // EOF

--- a/scripts/latency-tracker/master.groovy
+++ b/scripts/latency-tracker/master.groovy
@@ -528,7 +528,7 @@ for (b in allBuilds) {
 
 // Mark this build failed if any child build has failed
 if (isFailed) {
-  build.getExecutor().interrupt(Result.FAILURE)
+  build.setResult(hudson.model.Result.FAILURE)
 }
 
 // EOF

--- a/scripts/lttng-modules/master-rt.groovy
+++ b/scripts/lttng-modules/master-rt.groovy
@@ -354,7 +354,7 @@ for (b in allBuilds) {
 
 // Mark this build failed if any child build has failed
 if (isFailed) {
-  build.getExecutor().interrupt(Result.FAILURE)
+  build.setResult(hudson.model.Result.FAILURE)
 }
 
 // EOF

--- a/scripts/lttng-modules/master.groovy
+++ b/scripts/lttng-modules/master.groovy
@@ -528,7 +528,7 @@ for (b in allBuilds) {
 
 // Mark this build failed if any child build has failed
 if (isFailed) {
-  build.getExecutor().interrupt(Result.FAILURE)
+  build.setResult(hudson.model.Result.FAILURE)
 }
 
 // EOF


### PR DESCRIPTION
getExecutor().interrupt(FAILURE) flag the build as aborted event if the final status is FAILURE.
This influence triggers such as email.

07:28:26 lttng-modules_VERSION_param-build #334163 (v4.12.14) completed with status SUCCESS
07:28:26 lttng-modules_VERSION_param-build #334160 (v4.15-rc3) completed with status FAILURE
...
07:28:26 lttng-modules_VERSION_param-build #334220 (v2.6.37.6) completed with status SUCCESS
07:28:26 Build was aborted

Marked as "aborted".

07:28:26 Started calculate disk usage of build
07:28:26 Finished Calculation of disk usage of build in 0 seconds
07:28:26 Started calculate disk usage of workspace
07:28:26 Finished Calculation of disk usage of workspace in 0 seconds
07:28:26 [WS-CLEANUP] Deleting project workspace...[WS-CLEANUP] done
07:28:26 No emails were triggered.

An email should have been fired here.

07:28:26 Finished: FAILURE

Final status is Failure. But no email were sent.

Signed-off-by: Jonathan Rajotte <jonathan.rajotte-julien@efficios.com>