### PR TITLE
Use github.com/lttng/jenkins-job-builder instead of a personal repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ can be installed directly from github :
 
     $ virtualenv -p python2 .venv
     $ . .venv/bin/activate
-    $ pip install git+git://github.com/psrcode/jenkins-job-builder
+    $ pip install git+git://github.com/lttng/jenkins-job-builder
 
 
 ## Example Usage

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,5 @@ toxworkdir = {env:TOXWORKDIR:.tox}
 
 [testenv]
 skip_install = True
-deps = git+git://github.com/psrcode/jenkins-job-builder
+deps = git+git://github.com/lttng/jenkins-job-builder
 commands = jenkins-jobs --conf etc/jenkins_jobs.ini-tox test jobs/ -o test/


### PR DESCRIPTION
Signed-off-by: Jonathan Rajotte <jonathan.rajotte-julien@efficios.com>