### PR TITLE
jjb: lava: kprobe-fuzzing: Don't setup lttng env

### DIFF
--- a/scripts/system-tests/lava-submit.py
+++ b/scripts/system-tests/lava-submit.py
@@ -463,7 +463,6 @@ def main():
             print('Tests runs need -uc/--ust-commit options. Exiting...')
             return -1
         j['actions'].append(get_config_cmd('kvm'))
-        j['actions'].append(get_env_setup_cmd('kvm', args.tools_commit, args.ust_commit))
         j['actions'].append(get_kprobes_generate_data_cmd())
         j['actions'].append(get_kprobes_test_cmd())
         j['actions'].append(get_results_cmd(stream_name='tests-kernel'))


### PR DESCRIPTION
We now use the debugfs interface to enable kprobe events, so we don't
need to setup an LTTng env anymore.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>