### PR TITLE
jjb: lava: kprobe-fuzzing: Split testcase into multiple independent ones

### DIFF
--- a/lava/system-tests/kprobe-fuzzing-generate-data.yml
+++ b/lava/system-tests/kprobe-fuzzing-generate-data.yml
@@ -7,8 +7,10 @@ install:
                 - url: https://github.com/lttng/lttng-ci
                   destination: ci
                   branch: master
+params:
+  RANDOM_SEED=12345
 run:
         steps:
                 - cd ci/
-                - lava-test-case generate-fuzzing-data --shell "python3 ./scripts/system-tests/run-kprobe-generate-instr-points.py $((1 + RANDOM))"
+                - lava-test-case generate-fuzzing-data --shell "python3 ./scripts/system-tests/run-kprobe-generate-instr-points.py $RANDOM_SEED"
                 - sync

--- a/lava/system-tests/kprobe-fuzzing-tests.yml
+++ b/lava/system-tests/kprobe-fuzzing-tests.yml
@@ -12,10 +12,12 @@ install:
                 - ulimit -c unlimited
                 - mkdir -p coredump
                 - echo "$(pwd)/coredump/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+params:
+  ROUND_NB: 0
 run:
         steps:
                 - cd ci/
-                - lava-test-case run-fuzzing --shell "python3 ./scripts/system-tests/run-kprobe-fuzzing.py /root/instr_points.txt.gz"
+                - lava-test-case run-fuzzing --shell "python3 ./scripts/system-tests/run-kprobe-fuzzing.py /root/instr_points.txt.gz $ROUND_NB"
                 - cd ..
                 - tar czf coredump.tar.gz coredump
                 - lava-test-case-attach run-fuzzing coredump.tar.gz

--- a/scripts/system-tests/lava-submit.py
+++ b/scripts/system-tests/lava-submit.py
@@ -284,7 +284,7 @@ def get_kprobes_generate_data_cmd():
         })
     return command
 
-def get_kprobes_test_cmd():
+def get_kprobes_test_cmd(round_nb):
     command = OrderedDict({
         'command': 'lava_test_shell',
         'parameters': {
@@ -292,10 +292,11 @@ def get_kprobes_test_cmd():
                 {
                     'git-repo': 'https://github.com/lttng/lttng-ci.git',
                     'revision': 'master',
-                    'testdef': 'lava/system-tests/kprobe-fuzzing-tests.yml'
+                    'testdef': 'lava/system-tests/kprobe-fuzzing-tests.yml',
+                    'parameters': { 'ROUND_NB': str(round_nb) }
                 }
-                ],
-            'timeout': 7200
+            ],
+            'timeout': 1000
             }
         })
     return command
@@ -464,7 +465,8 @@ def main():
             return -1
         j['actions'].append(get_config_cmd('kvm'))
         j['actions'].append(get_kprobes_generate_data_cmd())
-        j['actions'].append(get_kprobes_test_cmd())
+        for i in range(10):
+            j['actions'].append(get_kprobes_test_cmd(round_nb=i))
         j['actions'].append(get_results_cmd(stream_name='tests-kernel'))
     else:
         assert False, 'Unknown test type'

--- a/scripts/system-tests/lava-submit.py
+++ b/scripts/system-tests/lava-submit.py
@@ -18,6 +18,7 @@ import argparse
 import base64
 import json
 import os
+import random
 import sys
 import time
 import xmlrpc.client
@@ -269,6 +270,7 @@ def get_kvm_tests_cmd():
     return command
 
 def get_kprobes_generate_data_cmd():
+    random_seed = random.randint(0, 1000000)
     command = OrderedDict({
         'command': 'lava_test_shell',
         'parameters': {
@@ -276,7 +278,8 @@ def get_kprobes_generate_data_cmd():
                 {
                     'git-repo': 'https://github.com/lttng/lttng-ci.git',
                     'revision': 'master',
-                    'testdef': 'lava/system-tests/kprobe-fuzzing-generate-data.yml'
+                    'testdef': 'lava/system-tests/kprobe-fuzzing-generate-data.yml',
+                    'parameters': { 'RANDOM_SEED': str(random_seed) }
                 }
                 ],
             'timeout': 60

--- a/scripts/system-tests/run-kprobe-fuzzing.py
+++ b/scripts/system-tests/run-kprobe-fuzzing.py
@@ -55,15 +55,17 @@ def set_kprobe_tracing_state(state):
     if state not in (0 ,1):
         raise ValueError
 
-    if state == 0:
-        # Clear the content of the trace.
-        open('/sys/kernel/debug/tracing/trace', 'w').close()
-
     try:
         with open('/sys/kernel/debug/tracing/events/kprobes/enable', 'w') as enable_kprobe_file:
             enable_kprobe_file.write('{}\n'.format(state))
     except IOError:
         print('kprobes/enable file does not exist')
+
+    if state == 0:
+        # Clear the content of the trace.
+        open('/sys/kernel/debug/tracing/trace', 'w').close()
+        # Clear all the events.
+        open('/sys/kernel/debug/tracing/kprobe_events', 'w').close()
 
 def run_workload():
     print('Running workload...', end='')

--- a/scripts/system-tests/run-kprobe-fuzzing.py
+++ b/scripts/system-tests/run-kprobe-fuzzing.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 
 NB_KPROBES_PER_ITER=500
+NB_KPROBES_PER_ROUND=20000
 
 def load_instr_points(instr_points_archive):
     print('Reading instrumentation points from \'{}\'.'.format(instr_points_archive), end='')
@@ -87,23 +88,31 @@ def print_dashed_line():
     print('-'*100)
 
 def main():
-    assert(len(sys.argv) == 2)
+    assert(len(sys.argv) == 3)
 
     instr_point_archive = sys.argv[1]
+    round_nb = int(sys.argv[2])
     # Load instrumentation points to disk and attach it to lava test run.
     instrumentation_points = load_instr_points(instr_point_archive)
+
+    # We are past the end of the instrumentation point list.
+    if len(instrumentation_points)/NB_KPROBES_PER_ROUND <= round_nb:
+        print('No instrumentation point for round {}.'.format(round_nb))
+        return
 
     mount_tracingfs()
 
     # Loop over the list by enabling ranges of NB_KPROBES_PER_ITER kprobes.
-    for i in range(int(len(instrumentation_points)/NB_KPROBES_PER_ITER)):
+    for i in range(int(NB_KPROBES_PER_ROUND/NB_KPROBES_PER_ITER)):
         print_dashed_line()
-        print('Time now: {}, {} to {}'.format(datetime.datetime.now(), i*NB_KPROBES_PER_ITER, (i+1)*NB_KPROBES_PER_ITER))
-        set_kprobe_tracing_state(0)
-        enable_kprobe_events(instrumentation_points[i*NB_KPROBES_PER_ITER:(i+1)*NB_KPROBES_PER_ITER])
+        lower_bound = (round_nb * NB_KPROBES_PER_ROUND) + (i * NB_KPROBES_PER_ITER)
+        upper_bound = lower_bound + NB_KPROBES_PER_ITER
+        print('Time now: {}, {} to {}'.format(datetime.datetime.now(), lower_bound , upper_bound))
+        enable_kprobe_events(instrumentation_points[lower_bound:upper_bound])
         set_kprobe_tracing_state(1)
         run_workload()
         print('\n')
+        set_kprobe_tracing_state(0)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
With the current configuration, the fuzzing is done in a single Lava
testcase. If the kernel crashes during the testcase, the Lava slave will
be rebooted once the timeout expires(currently 2 hours). If the testcase
crashes at the beginning of the testcase, the job still has to wait for
the timeout to expire. That causes a lot of wasted time.

We overcome this by split the fuzzing into multiple smaller testcases
all with a smaller timeout and a specific range of instrumentation
points to test. This has the benefits of increasing our testing coverage
and resource efficiency.

This PR also add the missing deactivation of the events after each iterations and add a seed parameter to the fuzzing data generation script.