### PR TITLE
jjb: lava: Schedule trigger jobs on early morning on week days

### DIFF
--- a/jobs/system-tests.yaml
+++ b/jobs/system-tests.yaml
@@ -370,7 +370,7 @@
           num-to-keep: 10
 
     triggers:
-      - timed: "H H * * 1-5"
+      - timed: "H 0 * * 1-5"
 
     wrappers:
       - timestamps


### PR DESCRIPTION
Because of DNS resolving downtime during backups on weekends we need to
make sure that the long running Lava jobs are scheduled early in the day
so they have time to complete before we pass midnight.

It was causing problems when a lot of Lava jobs were scheduled late
Friday afternoon and some jobs ended up being queued until Saturday
morning when DNS resolving was down.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>