### PR TITLE
Kill dangling test processes before running tests

### DIFF
--- a/jobs/lttng-tools.yaml
+++ b/jobs/lttng-tools.yaml
@@ -281,6 +281,19 @@
 - lttng-tools_build_publishers_dev: &lttng-tools_build_publishers_dev
     name: 'lttng-tools_build_publishers_dev'
     publishers:
+      - postbuildscript:
+          mark-unstable-if-failed: true
+          builders:
+            - role: SLAVE
+              build-on:
+                  - SUCCESS
+                  - UNSTABLE
+                  - NOT_BUILT
+                  - ABORTED
+                  - FAILURE
+              build-steps:
+                  - shell:
+                      !include-raw-escape: scripts/lttng-tools/hang_processes.sh
       - tap:
           results: 'tap/**/*.tap'
           failed-tests-mark-build-as-failure: true
@@ -322,6 +335,19 @@
 - lttng-tools_build_publishers_prod: &lttng-tools_build_publishers_prod
     name: 'lttng-tools_build_publishers_prod'
     publishers:
+      - postbuildscript:
+          mark-unstable-if-failed: true
+          builders:
+            - role: SLAVE
+              build-on:
+                  - SUCCESS
+                  - UNSTABLE
+                  - NOT_BUILT
+                  - ABORTED
+                  - FAILURE
+              build-steps:
+                  - shell:
+                      !include-raw-escape: scripts/lttng-tools/hang_processes.sh
       - tap:
           results: 'tap/**/*.tap'
           failed-tests-mark-build-as-failure: true

--- a/jobs/lttng-tools.yaml
+++ b/jobs/lttng-tools.yaml
@@ -367,7 +367,7 @@
           clean-if:
             - failure: false
       - archive:
-          artifacts: 'build/**'
+          artifacts: 'build/**, deps/**'
           allow-empty: false
       - email-ext:
           recipients: '{obj:email_to}'

--- a/jobs/lttng-tools.yaml
+++ b/jobs/lttng-tools.yaml
@@ -210,6 +210,8 @@
                 target: 'deps/lttng-ust'
                 do-not-fingerprint: true
       - shell:
+         !include-raw-escape: scripts/lttng-tools/clean_processes_coredump.sh
+      - shell:
          !include-raw-escape: scripts/lttng-tools/build.sh
 
 - lttng-tools_build_builders_win: &lttng-tools_build_builders_win

--- a/scripts/lttng-tools/build.sh
+++ b/scripts/lttng-tools/build.sh
@@ -339,6 +339,13 @@ if [ "$RUN_TESTS" = "yes" ]; then
     # Allow core dumps
     ulimit -c unlimited
 
+    # Kill any LTTng-related process
+    lttng_processes="$("$PGREP" -l 'lttng|gen-ust-.+')"
+    if [ $? -eq 0 ]; then
+        pids="$(cut -d ' ' -f 1 <<< "$lttng_processes" | tr '\n' ' ')"
+        kill -9 $pids
+    fi
+
     # Add 'babeltrace' binary to PATH
     chmod +x "$BABEL_BINS/babeltrace"
     export PATH="$PATH:$BABEL_BINS"

--- a/scripts/lttng-tools/build.sh
+++ b/scripts/lttng-tools/build.sh
@@ -342,8 +342,8 @@ if [ "$RUN_TESTS" = "yes" ]; then
     ulimit -c unlimited
 
     # Kill any LTTng-related process
-    lttng_processes="$("$PGREP" -l 'lttng|gen-ust-.+')"
-    if [ $? -eq 0 ]; then
+    lttng_processes="$("$PGREP" -l 'lttng|gen-ust-.+')" || true
+    if [ ! -z "$lttng_processes" ]; then
         echo "The following LTTng processes were detected running on the system and will be killed:"
         echo "$lttng_processes"
 

--- a/scripts/lttng-tools/build.sh
+++ b/scripts/lttng-tools/build.sh
@@ -102,6 +102,8 @@ UST_JAVA="$WORKSPACE/deps/lttng-ust/build/share/java/"
 BABEL_LIBS="$WORKSPACE/deps/babeltrace/build/lib/"
 BABEL_BINS="$WORKSPACE/deps/babeltrace/build/bin/"
 
+# pgrep
+PGREP=pgrep
 
 # Set platform variables
 case "$arch" in
@@ -342,8 +344,11 @@ if [ "$RUN_TESTS" = "yes" ]; then
     # Kill any LTTng-related process
     lttng_processes="$("$PGREP" -l 'lttng|gen-ust-.+')"
     if [ $? -eq 0 ]; then
+        echo "The following LTTng processes were detected running on the system and will be killed:"
+        echo "$lttng_processes"
+
         pids="$(cut -d ' ' -f 1 <<< "$lttng_processes" | tr '\n' ' ')"
-        kill -9 $pids
+        kill -SIGKILL $pids
     fi
 
     # Add 'babeltrace' binary to PATH

--- a/scripts/lttng-tools/build.sh
+++ b/scripts/lttng-tools/build.sh
@@ -341,16 +341,6 @@ if [ "$RUN_TESTS" = "yes" ]; then
     # Allow core dumps
     ulimit -c unlimited
 
-    # Kill any LTTng-related process
-    lttng_processes="$("$PGREP" -l 'lttng|gen-ust-.+')" || true
-    if [ ! -z "$lttng_processes" ]; then
-        echo "The following LTTng processes were detected running on the system and will be killed:"
-        echo "$lttng_processes"
-
-        pids="$(cut -d ' ' -f 1 <<< "$lttng_processes" | tr '\n' ' ')"
-        kill -SIGKILL $pids
-    fi
-
     # Add 'babeltrace' binary to PATH
     chmod +x "$BABEL_BINS/babeltrace"
     export PATH="$PATH:$BABEL_BINS"

--- a/scripts/lttng-tools/clean_processes_coredump.sh
+++ b/scripts/lttng-tools/clean_processes_coredump.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -exu
+#
+# Copyright (C) 2018 - Jonathan Rajotte-Julien <jonathan.rajotte-julien@efficios.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+PGREP=pgrep
+# Kill any LTTng-related process
+lttng_processes="$("$PGREP" -l 'lttng|gen-ust-.+')" || true
+if [ ! -z "$lttng_processes" ]; then
+    echo "The following LTTng processes were detected running on the system and will be killed:"
+    echo "$lttng_processes"
+
+    pids="$(cut -d ' ' -f 1 <<< "$lttng_processes" | tr '\n' ' ')"
+    kill -SIGKILL $pids
+fi
+
+# Remove any coredump already present
+core_files=$(find "/tmp" -name "core\.[0-9]*" -type f 2>/dev/null) || true
+if [ ! -z "$core_files" ]; then
+    rm -rf $core_files
+fi

--- a/scripts/lttng-tools/hang_processes.sh
+++ b/scripts/lttng-tools/hang_processes.sh
@@ -25,7 +25,6 @@ lttng_processes="$("$PGREP" -l 'lttng|gen-ust-.+')" || true
 if [ ! -z "$lttng_processes" ]; then
 
     pids="$(cut -d ' ' -f 1 <<< "$lttng_processes" | tr '\n' ' ')"
-    comma_pids=$(tr ' ' ',' <<< "$pids")
     echo "The following LTTng processes were detected running on the system and will be aborted:"
     echo "$lttng_processes"
 

--- a/scripts/lttng-tools/hang_processes.sh
+++ b/scripts/lttng-tools/hang_processes.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -exu
+#
+# Copyright (C) 2018 - Jonathan Rajotte-Julien <jonathan.rajotte-julien@efficios.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+PGREP=pgrep
+pids=""
+dependencies=""
+file_list=$(mktemp)
+ret=0
+
+lttng_processes="$("$PGREP" -l 'lttng|gen-ust-.+')" || true
+if [ ! -z "$lttng_processes" ]; then
+
+    pids="$(cut -d ' ' -f 1 <<< "$lttng_processes" | tr '\n' ' ')"
+    comma_pids=$(tr ' ' ',' <<< "$pids")
+    echo "The following LTTng processes were detected running on the system and will be aborted:"
+    echo "$lttng_processes"
+
+    # Stop the processes to make sure everything is frozen
+    kill -SIGSTOP $pids
+
+    # Get dependencies for coredump analysis
+    # Use /proc/$PID/exe and ldd to get all shared libs necessary
+    array=(${pids})
+    # Add the /proc/ prefix using parameter expansion
+    array=("${array[@]/#/\/proc\/}")
+    # Add the /exe suffix using parameter expansion
+    array=("${array[@]/%/\/exe}")
+    dependencies=$(ldd "${array[@]}" | grep -v "not found")
+    dependencies=$(awk '/=>/{print$(NF-1)}' <<< "$dependencies" | sort | uniq)
+
+    kill -SIGABRT $pids
+    kill -SIGCONT $pids
+    ret=1
+fi
+
+core_files=$(find "/tmp" -name "core\.[0-9]*" -type f 2>/dev/null) || true
+if [ ! -z "$core_files" ]; then
+    echo "$core_files" >> "$file_list"
+    echo "$dependencies" >> "$file_list"
+
+    # Make sure the coredump is finished using fuser
+    for core in $core_files; do
+        while fuser "$core"; do
+            sleep 1
+        done
+    done
+
+    tar cfzh "${WORKSPACE}/build/core.tar.gz" -T "$file_list"
+    rm -rf $core_files
+    ret=1
+fi
+
+rm -rf "$file_list"
+exit $ret


### PR DESCRIPTION
Tests often fail because of "dangling" lttng processes left on CI slaves. I am not sure what leaks them (either failing tests or cancelled jobs), but they are a very frequent cause of build failures.

The code is this diff is taken from lttng-tools' `warn_processes.sh`.

We could also clean-up at the end of the job, but I am not sure how to get Jenkins to run a "clean-up" when a job is cancelled (e.g. manually or after a time-out).