### PR TITLE
Increase lttng-tools test timeout to 120 minutes

### DIFF
--- a/jobs/lttng-tools.yaml
+++ b/jobs/lttng-tools.yaml
@@ -13,7 +13,7 @@
     wrappers:
       - ansicolor
       - timeout:
-          timeout: 90
+          timeout: 120
           fail: true
           type: absolute
       - timestamps


### PR DESCRIPTION
Some of the slower workers (Cubietrucks) can't finish running the
lttng-tools CI jobs (with agent tests enabled) in 90 minutes.

I'm not sure if this is the proper fix... Maybe we can boost the timeout just for those slower targets?

WDYT?