### PR TITLE
jjb: add babeltrace scan-build configure options

### DIFF
--- a/scripts/common/scan-build.sh
+++ b/scripts/common/scan-build.sh
@@ -41,6 +41,8 @@ SCAN_BUILD_TMPDIR=$( mktemp -d )
 case "$PROJECT_NAME" in
 babeltrace)
     export BABELTRACE_DEV_MODE=1
+    export BABELTRACE_DEBUG_MODE=1
+    export BABELTRACE_MINIMAL_LOG_LEVEL=TRACE
     CONF_OPTS="--enable-python-bindings --enable-python-bindings-doc --enable-python-plugins"
     BUILD_TYPE="autotools"
     ;;


### PR DESCRIPTION
These options prevent a lot of false positive reports, mainly in cases
where variable are set only used in assertions or some log levels.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>