### PR TITLE
jjb: system-tests: use `yaml.unsafe_unload()` method

### DIFF
--- a/scripts/system-tests/lava2-submit.py
+++ b/scripts/system-tests/lava2-submit.py
@@ -114,7 +114,7 @@ def print_test_output(server, job):
     Parse the attachment of the testcase to fetch the stdout of the test suite
     """
     job_finished, log = server.scheduler.jobs.logs(str(job))
-    logs = yaml.load(log.data.decode('ascii'))
+    logs = yaml.unsafe_load(log.data.decode('ascii'))
     print_line = False
     for line in logs:
         if line['lvl'] != 'target':


### PR DESCRIPTION
Since PyYAML version 5.2 `load()` errors out when parsing such field:
  !!python/object/apply:collections.OrderedDict [...]

This is done to prevent vulnerabilities exploitable using the
`object/apply` construct. See this Github issue [1]:

I believe the real bug is that Lava produce a yaml file with such a
construct. I believe it's not on purpose because we can see a commit [2]
preventing the use of `object/apply` for another type.

For now, use `unsafe_load()` until lava does not produce `object/apply`
contructs.

[1] https://github.com/yaml/pyyaml/issues/364
[2] https://github.com/Linaro/lava/commit/14b347c51efb89e8d6c64d9aa74fb4190f03227c

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>