### PR TITLE
jjb: system-tests: print all tests results

### DIFF
--- a/scripts/system-tests/lava2-submit.py
+++ b/scripts/system-tests/lava2-submit.py
@@ -125,7 +125,8 @@ def print_test_output(server, job):
             continue
         if line['msg'] == '<LAVA_SIGNAL_ENDTC run-tests>':
             print('----- TEST SUITE OUTPUT END -----')
-            break
+            print_line = False
+            continue
         if print_line:
             print("{} {}".format(line['dt'], line['msg']))
 


### PR DESCRIPTION
In the vm_tests_* lava jobs, there are currently 2 sub-tests that we
care about: "1_kernel-tests" and "2_destructive-tests".

At the moment, we print from the first '<LAVA_SIGNAL_STARTTC run-tests>'
to the first '<LAVA_SIGNAL_ENDTC run-tests>' we encounter.

This is wrong because there are 2 sub-tests, we are currently only print
the result of the first one.

To fix this,  don't break from the loop and keep on reading the file in
case there are other test results.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>