### PR TITLE
Fix: jjb: system-tests: pass modules repo to build job

### DIFF
--- a/scripts/system-tests/generate-properties-master.sh
+++ b/scripts/system-tests/generate-properties-master.sh
@@ -46,6 +46,7 @@ echo "STORAGE_USER=jenkins-lava" >> properties.txt
 
 echo "BUILD_DEVICE=$BUILD_DEVICE" >> properties.txt
 echo "KGITREPO=$KERNEL_REPO" >> properties.txt
+echo "LTTNG_MODULES_REPO=$LTTNG_MODULES_REPO" >> properties.txt
 echo "STORAGE_KERNEL_FOLDER=$BASE_STORAGE_FOLDER/kernel" >> properties.txt
 echo "STORAGE_KERNEL_IMAGE=$BASE_STORAGE_FOLDER/kernel/$KERNEL_COMMIT_ID.$BUILD_DEVICE.bzImage" >> properties.txt
 echo "STORAGE_LINUX_MODULES=$BASE_STORAGE_FOLDER/modules/linux/$KERNEL_COMMIT_ID.$BUILD_DEVICE.linux.modules.tar.gz" >> properties.txt


### PR DESCRIPTION
When passing a custom Git repository URL to a systems-test job, the
master job doesn't pass this URL to the kernel and modules building job.
This makes the job fail when it can't checkout the desired commit on the
default remote.

To fix this, pass the URL received in the job parameter to the kernel
and modules building job.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>