### PR TITLE
jjb: lttng-ust: keep 20 build reports

### DIFF
--- a/jobs/lttng-ust.yaml
+++ b/jobs/lttng-ust.yaml
@@ -34,7 +34,7 @@
           properties-content: |
             PROJECT_NAME=lttng-ust
       - build-discarder:
-          num-to-keep: 2
+          num-to-keep: 20
       - github:
           url: https://github.com/{github_user}/{github_name}
 


### PR DESCRIPTION
Having only limit of 2 build reports makes it difficult to troubleshoot
a build failure when updating multiple Gerrit change at the time.

This commit changes the limit to 20.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>