### PR TITLE
 jjb: lttng-tools: build userspace-probe SDT testapp

### DIFF
--- a/scripts/lttng-tools/build.sh
+++ b/scripts/lttng-tools/build.sh
@@ -282,6 +282,11 @@ fi
 # Most build configs require the python bindings
 CONF_OPTS=("--prefix=$PREFIX" "--enable-python-bindings")
 
+# Turn on SDT userspace-probe testing
+if vergte "$PACKAGE_VERSION" "2.11"; then
+    CONF_OPTS+=("--enable-test-sdt-uprobe")
+fi
+
 # Set configure options and environment variables for each build
 # configuration.
 case "$conf" in


### PR DESCRIPTION
Make all applicable configurations build the userspace-probe SDT tests.

These tests are not run by Jenkins because they require the kernel
tracer, but it's still useful to build the testapp to catch build
failures like it was witnessed with the glibc 2.30 package on Archlinux.Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>