### PR TITLE
jjb: system-tests: remove LTTng stable-2.9 tests

### DIFF
--- a/jobs/system-tests.yaml
+++ b/jobs/system-tests.yaml
@@ -384,7 +384,6 @@
     lttngversion:
       - canary
       - master
-      - stable-2.9
       - stable-2.10
       - stable-2.11
       - stable-2.12
@@ -398,7 +397,6 @@
       - linux-3.18.y
     lttngversion:
       - master
-      - stable-2.9
       - stable-2.10
       - stable-2.11
       - stable-2.12

--- a/scripts/system-tests/system-trigger.groovy
+++ b/scripts/system-tests/system-trigger.groovy
@@ -303,8 +303,7 @@ final String pastJobsPath = build.getEnvironment(listener).get('WORKSPACE') + "/
 def recentLttngBranchesOfInterest = ['master',
   'stable-2.12',
   'stable-2.11',
-  'stable-2.10',
-  'stable-2.9']
+  'stable-2.10']
 def recentLinuxBranchesOfInterest = ['master',
   'linux-5.1.y',
   'linux-5.0.y',


### PR DESCRIPTION
This release is no longer supported.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>